### PR TITLE
Maintenance maven dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.ipr
 target/
 .DS_Store
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>3.8.1</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <!-- OpenNMS Model for OnmsOutage -->
         <dependency>
             <groupId>org.opennms</groupId>
-            <artifactId>opennms-config-model</artifactId>
-            <version>1.11.3-SNAPSHOT</version>
+            <artifactId>opennms-model</artifactId>
+            <version>19.0.1</version>
             <type>jar</type>
             <exclusions>
                 <exclusion>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-json</artifactId>
-            <version>1.14</version>
+            <version>1.19.3</version>
             <type>jar</type>
         </dependency>
 
@@ -50,20 +50,20 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.1</version>
+            <version>1.7.24</version>
             <type>jar</type>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.0.7</version>
+            <version>1.2.1</version>
         </dependency>
 
         <dependency>
             <groupId>args4j</groupId>
             <artifactId>args4j</artifactId>
-            <version>2.32</version>
+            <version>2.33</version>
         </dependency>
 
         <dependency>
@@ -82,7 +82,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>3.5</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -91,7 +91,7 @@
 
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>foobar</id>
@@ -128,6 +128,19 @@
             <id>opennms-snapshots</id>
             <name>OpenNMS Snapshot Maven Repository</name>
             <url>http://maven.opennms.org/content/groups/opennms.org-snapshot</url>
+        </repository>
+
+        <!-- OpenNMS Repository to get the Model Classes -->
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <id>opennms-release</id>
+            <name>OpenNMS Releases Maven Repository</name>
+            <url>http://maven.opennms.org/content/groups/opennms.org-release</url>
         </repository>
     </repositories>
 </project>


### PR DESCRIPTION
Use opennms model dependency from current stable 19.0.1 release and not 1.11.3-SNAPSHOT. Bumped also all other dependencies to latest versions.